### PR TITLE
feat: implement config.Watcher for micro-config-service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/matoous/go-nanoid v1.5.1 // indirect
+	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.54.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,7 @@ github.com/matoous/go-nanoid v1.5.1 h1:aCjdvTyO9LLnTIi0fgdXhOPPvOHjpXN6Ik9DaNjIc
 github.com/matoous/go-nanoid v1.5.1/go.mod h1:zyD2a71IubI24efhpvkJz+ZwfwagzgSO6UNiFsZKN7U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
-github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/service.go
+++ b/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"dario.cat/mergo"
 	pbgrpc "go.unistack.org/micro-config-service/v5/grpc"
@@ -188,7 +189,27 @@ func (c *serviceConfig) Name() string {
 }
 
 func (c *serviceConfig) Watch(ctx context.Context, opts ...config.WatchOption) (config.Watcher, error) {
-	return nil, fmt.Errorf("not implemented")
+	if c.client == nil {
+		return nil, fmt.Errorf("not initialized")
+	}
+	wopts := config.NewWatchOptions(opts...)
+	if wopts.MinInterval == 0 {
+		wopts.MinInterval = 5 * time.Second
+	}
+	if wopts.MaxInterval == 0 {
+		wopts.MaxInterval = 1 * time.Minute
+	}
+	w := &serviceWatcher{
+		client:  c.client,
+		service: c.service,
+		opts:    c.opts,
+		wopts:   wopts,
+		done:    make(chan struct{}),
+		vchan:   make(chan map[string]interface{}),
+		echan:   make(chan error),
+	}
+	go w.run()
+	return w, nil
 }
 
 func NewConfig(opts ...config.Option) *serviceConfig {

--- a/watcher.go
+++ b/watcher.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"context"
+	"reflect"
+
+	pb "go.unistack.org/micro-config-service/v5/proto"
+	"go.unistack.org/micro/v5/config"
+	"go.unistack.org/micro/v5/util/jitter"
+	rutil "go.unistack.org/micro/v5/util/reflect"
+)
+
+var _ config.Watcher = &serviceWatcher{}
+
+type serviceWatcher struct {
+	client  pb.ConfigClient
+	service string
+	opts    config.Options
+	wopts   config.WatchOptions
+	done    chan struct{}
+	vchan   chan map[string]interface{}
+	echan   chan error
+}
+
+func (w *serviceWatcher) run() {
+	ticker := jitter.NewTicker(w.wopts.MinInterval, w.wopts.MaxInterval)
+	defer ticker.Stop()
+
+	src := w.opts.Struct
+	if w.wopts.Struct != nil {
+		src = w.wopts.Struct
+	}
+
+	for {
+		select {
+		case <-w.done:
+			return
+		case <-ticker.C:
+			dst, err := rutil.Zero(src)
+			if err == nil {
+				rsp, err := w.client.Load(context.Background(), &pb.LoadRequest{Service: w.service})
+				if err == nil {
+					err = w.opts.Codec.Unmarshal(rsp.Config, dst)
+				}
+				if err != nil {
+					w.echan <- err
+					return
+				}
+			}
+			if err != nil {
+				w.echan <- err
+				return
+			}
+
+			srcmp, err := rutil.StructFieldsMap(src)
+			if err != nil {
+				w.echan <- err
+				return
+			}
+			dstmp, err := rutil.StructFieldsMap(dst)
+			if err != nil {
+				w.echan <- err
+				return
+			}
+
+			for sk, sv := range srcmp {
+				if reflect.DeepEqual(dstmp[sk], sv) {
+					delete(dstmp, sk)
+				}
+			}
+
+			if len(dstmp) > 0 {
+				w.vchan <- dstmp
+				src = dst
+			}
+		}
+	}
+}
+
+func (w *serviceWatcher) Next() (map[string]interface{}, error) {
+	select {
+	case <-w.done:
+		break
+	case err := <-w.echan:
+		return nil, err
+	case v, ok := <-w.vchan:
+		if !ok {
+			break
+		}
+		return v, nil
+	}
+	return nil, config.ErrWatcherStopped
+}
+
+func (w *serviceWatcher) Stop() error {
+	close(w.done)
+	return nil
+}


### PR DESCRIPTION
## Summary
Implement the `config.Watcher` interface for the service config backend, enabling polling-based config change detection over RPC.

## What's Changed
- **watcher.go** — New serviceWatcher implementation that:
  - Polls config via `client.Load()` RPC calls
  - Detects changes using field-level diff (rutil.StructFieldsMap + reflect.DeepEqual)
  - Configurable polling intervals via WatchOption (defaults: 5s min, 1m max)
  - Graceful shutdown via Stop()

- **service.go** — Replace Watch() stub with working implementation that creates and launches the watcher goroutine

## Implementation Details
- Mirrors the exact logic from micro-config-file/watcher.go, replacing file I/O with RPC calls
- Uses jitter.NewTicker for randomized polling intervals between min and max bounds
- Returns only changed fields as map[string]interface{} per the Watcher interface
- Implements interface compliance check with `var _ config.Watcher = &serviceWatcher{}`

## Testing
```bash
go build ./...
go vet ./...
```

No integration tests without a live service, but the implementation is type-safe and follows the established patterns from micro-config-file.